### PR TITLE
Fix typo in "missing info" message

### DIFF
--- a/functions/src/issues.ts
+++ b/functions/src/issues.ts
@@ -25,7 +25,7 @@ export const MSG_FOLLOW_TEMPLATE =
   "Make sure you provide all the required information.";
 
 export const MSG_MISSING_INFO =
-  "This issues does not have all the information required by the template.  " +
+  "This issue does not have all the information required by the template.  " +
   "Looks like you forgot to fill out some sections.  " +
   "Please update the issue with more information.";
 


### PR DESCRIPTION
Just noticed this on an issue (https://github.com/firebase/firebase-js-sdk/issues/752#issuecomment-385573590), so there you go.