### PR TITLE
Use working days for cron

### DIFF
--- a/functions/src/test/stale-issues-test.ts
+++ b/functions/src/test/stale-issues-test.ts
@@ -43,8 +43,10 @@ const NOW_TIME = new Date();
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const JUST_NOW = new Date(NOW_TIME.getTime() - 1000).toISOString();
-const FOUR_DAYS_AGO = new Date(NOW_TIME.getTime() - 4 * DAY_MS).toISOString();
-const EIGHT_DAYS_AGO = new Date(NOW_TIME.getTime() - 8 * DAY_MS).toISOString();
+const SEVEN_DAYS_AGO = new Date(NOW_TIME.getTime() - 7 * DAY_MS).toISOString();
+const FOURTEEN_DAYS_AGO = new Date(
+  NOW_TIME.getTime() - 14 * DAY_MS
+).toISOString();
 const THREE_MONTHS_AGO = new Date(
   NOW_TIME.getTime() - 90 * DAY_MS
 ).toISOString();
@@ -71,8 +73,8 @@ const STALE_ISSUE: types.internal.Issue = {
   body: "Body of my issue",
   user: { login: "some-user" },
   labels: [{ name: "stale" }],
-  created_at: EIGHT_DAYS_AGO,
-  updated_at: EIGHT_DAYS_AGO,
+  created_at: FOURTEEN_DAYS_AGO,
+  updated_at: FOURTEEN_DAYS_AGO,
   locked: false
 };
 
@@ -83,8 +85,8 @@ const NEEDS_INFO_ISSUE: types.internal.Issue = {
   body: "Body of my issue",
   user: { login: "some-user" },
   labels: [{ name: "needs-info" }],
-  created_at: FOUR_DAYS_AGO,
-  updated_at: FOUR_DAYS_AGO,
+  created_at: SEVEN_DAYS_AGO,
+  updated_at: SEVEN_DAYS_AGO,
   locked: false
 };
 
@@ -95,9 +97,9 @@ const NEW_CLOSED_ISSUE: types.internal.Issue = {
   body: "Body of my issue",
   user: { login: "some-user" },
   labels: [],
-  created_at: EIGHT_DAYS_AGO,
-  updated_at: EIGHT_DAYS_AGO,
-  closed_at: FOUR_DAYS_AGO,
+  created_at: FOURTEEN_DAYS_AGO,
+  updated_at: FOURTEEN_DAYS_AGO,
+  closed_at: SEVEN_DAYS_AGO,
   locked: false
 };
 
@@ -173,8 +175,8 @@ describe("Stale issue handler", async () => {
         login: "some-user"
       },
       labels: [{ name: "needs-info" }],
-      created_at: EIGHT_DAYS_AGO,
-      updated_at: EIGHT_DAYS_AGO,
+      created_at: FOURTEEN_DAYS_AGO,
+      updated_at: FOURTEEN_DAYS_AGO,
       locked: false
     };
 
@@ -182,8 +184,8 @@ describe("Stale issue handler", async () => {
       {
         body: "My comment",
         user: { login: "some-user" },
-        created_at: EIGHT_DAYS_AGO,
-        updated_at: EIGHT_DAYS_AGO
+        created_at: FOURTEEN_DAYS_AGO,
+        updated_at: FOURTEEN_DAYS_AGO
       }
     ];
 
@@ -221,8 +223,8 @@ describe("Stale issue handler", async () => {
         login: "some-user"
       },
       labels: [{ name: "stale" }],
-      created_at: FOUR_DAYS_AGO,
-      updated_at: FOUR_DAYS_AGO,
+      created_at: SEVEN_DAYS_AGO,
+      updated_at: SEVEN_DAYS_AGO,
       locked: false
     };
 
@@ -230,14 +232,14 @@ describe("Stale issue handler", async () => {
       {
         body: "My original comment",
         user: { login: "some-user" },
-        created_at: FOUR_DAYS_AGO,
-        updated_at: FOUR_DAYS_AGO
+        created_at: SEVEN_DAYS_AGO,
+        updated_at: SEVEN_DAYS_AGO
       },
       {
         body: cron_handler.getMarkStaleComment("some-user", 7, 3),
         user: { login: "google-oss-bot" },
-        created_at: FOUR_DAYS_AGO,
-        updated_at: FOUR_DAYS_AGO
+        created_at: SEVEN_DAYS_AGO,
+        updated_at: SEVEN_DAYS_AGO
       }
     ];
 
@@ -280,8 +282,8 @@ describe("Stale issue handler", async () => {
         { name: "needs-info" },
         { name: "stale" }
       ],
-      created_at: EIGHT_DAYS_AGO,
-      updated_at: EIGHT_DAYS_AGO,
+      created_at: FOURTEEN_DAYS_AGO,
+      updated_at: FOURTEEN_DAYS_AGO,
       locked: false
     };
 
@@ -304,8 +306,8 @@ describe("Stale issue handler", async () => {
     const comment: types.internal.Comment = {
       user: STALE_ISSUE.user,
       body: "New comment by the author",
-      created_at: FOUR_DAYS_AGO,
-      updated_at: FOUR_DAYS_AGO
+      created_at: SEVEN_DAYS_AGO,
+      updated_at: SEVEN_DAYS_AGO
     };
 
     const actions = await issue_handler.onCommentCreated(
@@ -369,8 +371,8 @@ describe("Stale issue handler", async () => {
     const comment: types.internal.Comment = {
       user: { login: "someone-else" },
       body: "New comment by someone else",
-      created_at: FOUR_DAYS_AGO,
-      updated_at: FOUR_DAYS_AGO
+      created_at: SEVEN_DAYS_AGO,
+      updated_at: SEVEN_DAYS_AGO
     };
 
     const actions = await issue_handler.onCommentCreated(

--- a/functions/src/test/util-test.ts
+++ b/functions/src/test/util-test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import "mocha";
+
+import * as assert from "assert";
+import * as log from "../log";
+import * as util from "../util";
+
+describe("Configuration", async () => {
+  before(() => {
+    log.setLogLevel(log.Level.WARN);
+  });
+
+  after(() => {
+    log.setLogLevel(log.Level.ALL);
+  });
+
+  it("should properly calculate days and working days ago", async () => {
+    const tueDec31 = new Date(Date.parse("2019-12-31"));
+    const wedJan1 = new Date(Date.parse("2020-01-01"));
+    const friJan3 = new Date(Date.parse("2020-01-03"));
+    const monJan6 = new Date(Date.parse("2020-01-06"));
+
+    assert.equal(util.daysAgo(tueDec31, wedJan1), 1, "daysAgo Tues --> Weds");
+    assert.equal(
+      util.workingDaysAgo(tueDec31, wedJan1),
+      1,
+      "workingDaysAgo Tues --> Weds"
+    );
+
+    assert.equal(util.daysAgo(wedJan1, friJan3), 2, "daysAgo Weds --> Fri");
+    assert.equal(
+      util.workingDaysAgo(wedJan1, friJan3),
+      2,
+      "workingDaysAgo Weds --> Fri"
+    );
+
+    assert.equal(util.daysAgo(wedJan1, monJan6), 5, "daysAgo Weds --> Mon");
+    assert.equal(
+      util.workingDaysAgo(wedJan1, monJan6),
+      3,
+      "workingDaysAgo Weds --> Mon"
+    );
+
+    assert.equal(util.daysAgo(friJan3, monJan6), 3, "daysAgo Fri --> Mon");
+    assert.equal(
+      util.workingDaysAgo(friJan3, monJan6),
+      1,
+      "workingDaysAgo Fri --> Mon"
+    );
+  });
+});

--- a/functions/src/util.ts
+++ b/functions/src/util.ts
@@ -61,6 +61,36 @@ export function samScore(open: number, closed: number): number {
   return Math.round(score * 1000) / 1000;
 }
 
+export function createdDate(obj: types.internal.Timestamped): Date {
+  return new Date(Date.parse(obj.created_at));
+}
+
+export function daysAgo(past: Date, future?: Date): number {
+  const msInDay = 24 * 60 * 60 * 1000;
+  const now = future || new Date();
+
+  const diff = now.getTime() - past.getTime();
+  return Math.floor(diff / msInDay);
+}
+
+export function workingDaysAgo(past: Date, future?: Date): number {
+  const msInDay = 24 * 60 * 60 * 1000;
+  const now = (future || new Date()).getTime();
+
+  let workingDays = 0;
+  let t = past.getTime();
+
+  while (t < now) {
+    t += msInDay;
+    const tDate = new Date(t);
+    if (tDate.getDay() !== 0 && tDate.getDay() !== 6) {
+      workingDays += 1;
+    }
+  }
+
+  return workingDays;
+}
+
 export function timeAgo(obj: types.internal.Timestamped): number {
   return Date.now() - Date.parse(obj.created_at);
 }


### PR DESCRIPTION
This PR makes the cron handler only consider business days (weekdays) making it less likely that  someone will have their stale issue closed just because a weekend passed.

cc @marcbaechinger @ashwinraghav @Feiyang1 @paulb777 @stewartmiles 