### PR TITLE
Customizable close labels

### DIFF
--- a/functions/src/cron.ts
+++ b/functions/src/cron.ts
@@ -19,7 +19,6 @@ import * as github from "./github";
 import * as log from "./log";
 import * as util from "./util";
 import * as types from "./types";
-import { close } from "fs";
 
 // Metadata the bot can leave in comments to mark its actions
 const EVT_MARK_STALE = "event: mark-stale";

--- a/functions/src/github.ts
+++ b/functions/src/github.ts
@@ -119,23 +119,12 @@ export class GitHubClient {
    * Closes an issue on a github repo.
    */
   closeIssue(org: string, name: string, issue_number: number): Promise<any> {
-    // Add the closed-by-bot label
-    const add_label = this.api.issues.addLabels({
-      owner: org,
-      repo: name,
-      issue_number,
-      labels: ["closed-by-bot"]
-    });
-
-    // Close the issue
-    const close_issue = this.api.issues.update({
+    return this.api.issues.update({
       owner: org,
       repo: name,
       issue_number,
       state: "closed"
     });
-
-    return Promise.all([add_label, close_issue]);
   }
 
   /**

--- a/functions/src/test/stale-issues-test.ts
+++ b/functions/src/test/stale-issues-test.ts
@@ -56,6 +56,10 @@ const DEFAULT_CONFIG: types.IssueCleanupConfig = {
   label_needs_info: "needs-info",
   label_needs_attention: "needs-attention",
   label_stale: "stale",
+  auto_close_labels: {
+    add: ["closed-by-bot", "add-on-close"],
+    remove: ["remove-on-close"]
+  },
   ignore_labels: ["feature-request"],
   needs_info_days: 7,
   stale_days: 3
@@ -271,7 +275,25 @@ describe("Stale issue handler", async () => {
         cron_handler.getCloseComment(issue.user.login),
         false
       ),
-      new types.GitHubCloseAction("samtstern", "bottest", issue.number)
+      new types.GitHubCloseAction("samtstern", "bottest", issue.number),
+      new types.GitHubAddLabelAction(
+        "samtstern",
+        "bottest",
+        issue.number,
+        "closed-by-bot"
+      ),
+      new types.GitHubAddLabelAction(
+        "samtstern",
+        "bottest",
+        issue.number,
+        "add-on-close"
+      ),
+      new types.GitHubRemoveLabelAction(
+        "samtstern",
+        "bottest",
+        issue.number,
+        "remove-on-close"
+      )
     ]);
   });
 

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -280,6 +280,10 @@ export interface IssueCleanupConfig {
   label_needs_info: string;
   label_needs_attention?: string;
   label_stale: string;
+  auto_close_labels?: {
+    add: string[];
+    remove: string[];
+  };
   ignore_labels?: string[];
   needs_info_days: number;
   stale_days: number;


### PR DESCRIPTION
@marcbaechinger please review

Adds a new configuration to customize what labels the bot adds/removes when closing a stale issue.