### PR TITLE
Don't run stale checker on a weekend

### DIFF
--- a/functions/src/cron.ts
+++ b/functions/src/cron.ts
@@ -19,7 +19,6 @@ import * as github from "./github";
 import * as log from "./log";
 import * as util from "./util";
 import * as types from "./types";
-import { locale } from "moment";
 
 // Metadata the bot can leave in comments to mark its actions
 const EVT_MARK_STALE = "event: mark-stale";

--- a/functions/src/util.ts
+++ b/functions/src/util.ts
@@ -80,7 +80,7 @@ export function getDateWorkingDaysBefore(start: Date, days: number): Date {
   let t = start.getTime();
   while (daysSubtracted < days) {
     const tDate = new Date(t);
-    if (tDate.getDay() !== 0 && tDate.getDay() !== 6) {
+    if (isWorkday(tDate)) {
       daysSubtracted += 1;
     }
 
@@ -100,12 +100,16 @@ export function workingDaysAgo(past: Date, future?: Date): number {
   while (t < now) {
     t += msInDay;
     const tDate = new Date(t);
-    if (tDate.getDay() !== 0 && tDate.getDay() !== 6) {
+    if (isWorkday(tDate)) {
       workingDays += 1;
     }
   }
 
   return workingDays;
+}
+
+export function isWorkday(date: Date): boolean {
+  return date.getDay() !== 0 && date.getDay() !== 6;
 }
 
 export function timeAgo(obj: types.internal.Timestamped): number {


### PR DESCRIPTION
Fixes #90

The cron job will skip the stale issue checking on non-workdays, printing out a message like this (of course it won't say Wednesday):

```
Not processing stale issues on a weekend: Wed Dec 23 2020 @ 1:56:17 PM (Europe/London)
```