### PR TITLE
Make 'regex' optional

### DIFF
--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -259,7 +259,7 @@ export interface ReportConfig {
 }
 
 export interface LabelConfig {
-  regex: string;
+  regex?: string;
   email?: string;
 }
 


### PR DESCRIPTION
The code already implies this but this makes the types match.