### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -198,7 +198,7 @@ export class SendEmailAction extends Action {
   toString() {
     let subjectPreview = this.subject;
     if (subjectPreview.length > 20) {
-      subjectPreview = subjectPreview.substr(0, 17) + "...";
+      subjectPreview = subjectPreview.slice(0, 17) + "...";
     }
 
     return `SendEmailAction(${this.recipient}, ${subjectPreview})`;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.