### PR TITLE
feat: lock spam issues after they're closed

### DIFF
--- a/functions/src/github.ts
+++ b/functions/src/github.ts
@@ -136,6 +136,7 @@ export class GitHubClient {
       repo: name,
       issue_number,
       state: "closed",
+      state_reason: "not_planned",
       title: "Spam",
       body: "This issue was filtered as spam."
     });

--- a/functions/src/issues.ts
+++ b/functions/src/issues.ts
@@ -275,7 +275,8 @@ export class IssueHandler {
     });
 
     if (isSpam) {
-      // Discard other actions and wipe the issue.
+      // Discard other actions, wipe and lock the issue, and block
+      // the offending user.
       const reason = `Issue is believed to be spam: ${issue.title}`
       return [
         new types.GitHubSpamAction(
@@ -283,6 +284,9 @@ export class IssueHandler {
         ),
         new types.GitHubBlockAction(
           org, issue.user.login
+        ),
+        new types.GitHubLockAction(
+          org, name, issue.number
         )
       ];
     }


### PR DESCRIPTION
This should prevent spammers from commenting on their spam issues after the bot has already closed them.

It also adds a close reason for issues to be closed as "not planned" instead of "completed".