### PR TITLE
feat: block spammers at the organization level

### DIFF
--- a/functions/src/github.ts
+++ b/functions/src/github.ts
@@ -162,6 +162,16 @@ export class GitHubClient {
   }
 
   /**
+   * Blocks the given user on behalf of the specified organization.
+   */
+  blockFromOrg(org: string, username: string) {
+    return this.api.request('PUT /orgs/' + org + '/blocks/' + username, {
+      org: org,
+      username: username,
+    });
+  }
+
+  /**
    * Gets information about a GitHub repo.
    */
   async getRepo(org: string, repo: string) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -386,6 +386,12 @@ async function executeAction(action: types.Action): Promise<any> {
       wipeAction.name,
       wipeAction.number
     );
+  } else if (action.type == types.ActionType.GITHUB_BLOCK) {
+    const blockAction = action as types.GitHubBlockAction;
+    actionPromise = gh_client.blockFromOrg(
+      blockAction.org,
+      blockAction.username
+    );
   } else if (action.type == types.ActionType.GITHUB_LOCK) {
     const lockAction = action as types.GitHubLockAction;
     actionPromise = gh_client.lockIssue(

--- a/functions/src/issues.ts
+++ b/functions/src/issues.ts
@@ -280,6 +280,9 @@ export class IssueHandler {
       return [
         new types.GitHubSpamAction(
           org, name, issue.number, reason
+        ),
+        new types.GitHubBlockAction(
+          org, issue.user.login
         )
       ];
     }

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -13,6 +13,7 @@ export enum ActionType {
   GITHUB_LOCK = "GITHUB_LOCK",
   GITHUB_NO_OP = "GITHUB_NO_OP",
   GITHUB_SPAM = "GITHUB_SPAM",
+  GITHUB_BLOCK = "GITHUB_BLOCK",
   EMAIL_SEND = "EMAIL_SEND"
 }
 
@@ -23,6 +24,7 @@ export const GITHUB_ISSUE_ACTIONS = [
   ActionType.GITHUB_CLOSE,
   ActionType.GITHUB_LOCK,
   ActionType.GITHUB_NO_OP,
+  ActionType.GITHUB_BLOCK,
   ActionType.GITHUB_SPAM
 ];
 
@@ -158,6 +160,17 @@ export class GitHubSpamAction extends GitHubIssueAction {
     if (reason) {
       this.reason = reason;
     }
+  }
+}
+
+export class GitHubBlockAction extends Action {
+  org: string;
+  username: string;
+
+  constructor(org: string, username: string) {
+    super(ActionType.GITHUB_BLOCK);
+    this.org = org;
+    this.username = username;
   }
 }
 


### PR DESCRIPTION
This should block the spammer at the org level, preventing them from creating multiple spam issues - they get blocked right after the first spam instance (hopefully).

Note that this [may require some permissions](https://docs.github.com/en/rest/orgs/blocking?apiVersion=2022-11-28#list-users-blocked-by-an-organization) that I'm not sure if the bot has at the moment.