### PR TITLE
Add pages to nav

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,9 +53,10 @@
           <a class="brand" href="#">ossbot.computer</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li class="active"><a href="#">Home</a></li>
-              <li><a href="#">Foo</a></li>
-              <li><a href="#">Bar</a></li>
+              <li class="active"><a href="/">Home</a></li>
+              <li><a href="/charts.html">Charts</a></li>
+              <li><a href="/samscore.html">SAM Score</a></li>
+              <li><a href="/audit.html?org=firebase&repo=oss-bot">Audit Log</a></li>
             </ul>
           </div>
           <!--/.nav-collapse -->

--- a/public/samscore.html
+++ b/public/samscore.html
@@ -62,9 +62,10 @@
           <a class="brand" href="#">ossbot.computer</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li class="active"><a href="#">Home</a></li>
-              <li><a href="#">Foo</a></li>
-              <li><a href="#">Bar</a></li>
+              <li><a href="/">Home</a></li>
+              <li><a href="/charts.html">Charts</a></li>
+              <li class="active"><a href="/samscore.html">SAM Score</a></li>
+              <li><a href="/audit.html?org=firebase&repo=oss-bot">Audit Log</a></li>
             </ul>
           </div>
           <!--/.nav-collapse -->


### PR DESCRIPTION
Right now the nav in ossbot.computer just has "Foo" and "Bar". This makes it easier to find the other pages.