### PR TITLE
Add an error state to charts.html

### DIFF
--- a/public/charts.css
+++ b/public/charts.css
@@ -10,6 +10,12 @@ body {
   display: unset;
 }
 
+#chart-error {
+  color: red;
+  display: none;
+  margin-bottom: 10px;
+}
+
 td {
   text-align: left !important;
   vertical-align: middle;

--- a/public/charts.html
+++ b/public/charts.html
@@ -82,6 +82,7 @@
       <article>
         <h2>Results</h2>
         <div id="chart-content" class="card">
+          <div id="chart-error" style="color: red; display: none; margin-bottom: 10px;"></div>
           <img id="chart-loading" src="/assets/img/loading.gif" width="50px" />
           <canvas class="chart"></canvas>
         </div>

--- a/public/charts.html
+++ b/public/charts.html
@@ -82,7 +82,7 @@
       <article>
         <h2>Results</h2>
         <div id="chart-content" class="card">
-          <div id="chart-error" style="color: red; display: none; margin-bottom: 10px;"></div>
+          <div id="chart-error"></div>
           <img id="chart-loading" src="/assets/img/loading.gif" width="50px" />
           <canvas class="chart"></canvas>
         </div>

--- a/public/charts.js
+++ b/public/charts.js
@@ -151,18 +151,34 @@ function getQueryUrl(opts) {
 async function fetchQueryData(opts) {
   const url = getQueryUrl(opts);
   const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch data: ${res.status} ${res.statusText}`);
+  }
   return res.json();
 }
 
 async function withLoading(fn) {
   const loading = this.document.querySelector("#chart-loading");
+  const errorDiv = this.document.querySelector("#chart-error");
+  if (errorDiv) {
+    errorDiv.style.display = "none";
+    errorDiv.textContent = "";
+  }
   loading.classList.add("visible");
   lockFields();
 
-  await fn();
-
-  unlockFields();
-  loading.classList.remove("visible");
+  try {
+    await fn();
+  } catch (err) {
+    console.error(err);
+    if (errorDiv) {
+      errorDiv.style.display = "block";
+      errorDiv.textContent = `Error: ${err.message || err}`;
+    }
+  } finally {
+    unlockFields();
+    loading.classList.remove("visible");
+  }
 }
 
 function lockFields() {
@@ -243,6 +259,12 @@ const onDocReady = function (cb) {
 window.resetChart = function () {
   clearChart();
   unlockFields();
+
+  const errorDiv = document.querySelector("#chart-error");
+  if (errorDiv) {
+    errorDiv.style.display = "none";
+    errorDiv.textContent = "";
+  }
 
   resetSeriesState();
   CHART_AXES = [];

--- a/public/charts.js
+++ b/public/charts.js
@@ -158,8 +158,8 @@ async function fetchQueryData(opts) {
 }
 
 async function withLoading(fn) {
-  const loading = this.document.querySelector("#chart-loading");
-  const errorDiv = this.document.querySelector("#chart-error");
+  const loading = document.querySelector("#chart-loading");
+  const errorDiv = document.querySelector("#chart-error");
   if (errorDiv) {
     errorDiv.style.display = "none";
     errorDiv.textContent = "";
@@ -289,7 +289,7 @@ window.addSeriesFromForm = async function () {
 };
 
 onDocReady(() => {
-  const chartCard = this.document.querySelector("#chart-content");
+  const chartCard = document.querySelector("#chart-content");
   const chart = chartCard.querySelector("canvas");
   chartContext = chart.getContext("2d");
   


### PR DESCRIPTION
Right now, it just spins forever if the request fails (which it does due to #202).

 
<img width="1603" height="793" alt="Screenshot 2026-06-04 at 2 34 30 PM" src="https://github.com/user-attachments/assets/831d9ede-76c5-4d3c-8c26-72da5840751e" />
